### PR TITLE
Migrated Textures to TextureManager

### DIFF
--- a/PA26/CMakeLists.txt
+++ b/PA26/CMakeLists.txt
@@ -35,7 +35,7 @@ INCLUDE_DIRECTORIES(
 
 
 # Set Includes
-SET(INCLUDES ${PROJECT_SOURCE_DIR}/include include/Vertex.h)
+SET(INCLUDES ${PROJECT_SOURCE_DIR}/include)
 INCLUDE_DIRECTORIES(${INCLUDES})
 
 # Set sources

--- a/PA26/include/object.h
+++ b/PA26/include/object.h
@@ -22,11 +22,10 @@ public:
     Object();
     ~Object();
     bool Init(const std::string& filename);
-    bool Init(const std::string& objFilename, const std::string& textureFilename);
     void Update(unsigned int dt);
     void Render();
     bool LoadVerticiesFromFile(const std::string& filename);
-    bool LoadTextureData(const std::string& filename);
+    void SetTextureID(const std::string& textID);
 
     glm::mat4 GetModel();
     void setModel(const glm::mat4& incomingMatrix);
@@ -37,10 +36,7 @@ private:
     std::vector<unsigned int> indices;
     GLuint VBO;
     GLuint IBO;
-    GLuint TBO;
-
-    Magick::Blob blob;
-    unsigned int m_texture_width, m_texture_height;
+    std::string textureID;
 
 };
 

--- a/PA26/include/texture.h
+++ b/PA26/include/texture.h
@@ -1,0 +1,27 @@
+//
+// Created by Daniel Lopez on 10/30/17.
+//
+
+#ifndef TUTORIAL_TEXTURE_H
+#define TUTORIAL_TEXTURE_H
+
+
+#include <string>
+#include <Magick++.h>
+
+#include "graphics_headers.h"
+
+class Texture {
+public:
+    Texture();
+    ~Texture();
+    bool loadTexture(const std::string& filename);
+    void enable(GLenum textureUnit);
+    void disable();
+
+private:
+    GLuint textureHandler;
+};
+
+
+#endif //TUTORIAL_TEXTURE_H

--- a/PA26/include/textureManager.h
+++ b/PA26/include/textureManager.h
@@ -1,0 +1,36 @@
+//
+// Created by Daniel Lopez on 10/30/17.
+//
+
+#ifndef TUTORIAL_TEXTUREMANAGER_H
+#define TUTORIAL_TEXTUREMANAGER_H
+
+#include <string>
+#include <map>
+
+using namespace std;
+
+#include "graphics_headers.h"
+#include "texture.h"
+#include "shader.h"
+
+class TextureManager {
+public:
+    static TextureManager* getInstance();
+
+    bool initHandler(Shader *shaderManager);
+    bool addTexture(const string textName, string fileName);
+    void setTextureUnit(unsigned int samplerIndex);
+    void enableTexture(string textName, GLenum textureUnit);
+    void disableTexture(string textName);
+
+private:
+    TextureManager();
+
+    static TextureManager* instance;
+    GLint samplerHander;
+    map<string, Texture*> textures;
+};
+
+
+#endif //TUTORIAL_TEXTUREMANAGER_H

--- a/PA26/shaders/simple_lighting_fragment.glsl
+++ b/PA26/shaders/simple_lighting_fragment.glsl
@@ -15,8 +15,17 @@ out vec4 frag_color;
 uniform vec4 light;
 uniform sampler2D gSampler;
 uniform sampler2D gShadowMap;
+uniform sampler2D gNormalMap;
 
 vec3 CalcBumpedNormal() {
+    vec3 normal = normalize(vNormInWorld);
+    vec3 tangent = normalize(vTangInWorld);
+    tangent = normalize(tangent - dot(tangent, normal) * normal);
+    vec3 bitangent = cross(tangent, normal);
+    vec3 bumpMapNormal = texture(gNormalMap, uv).xyz;
+    bumpMapNormal = 2.0* bumpMapNormal - vec3(1.0, 1.0, 1.0);
+    vec3 newNormal = mat3(tangent, bitangent, normal) * bumpMapNormal;
+    return normalize(newNormal);
     return vec3(0.0);
 }
 

--- a/PA26/src/graphics.cpp
+++ b/PA26/src/graphics.cpp
@@ -1,4 +1,5 @@
 #include <shadowMapFBO.h>
+#include <textureManager.h>
 #include "graphics.h"
 
 Graphics::Graphics() {
@@ -43,11 +44,11 @@ bool Graphics::Initialize(int width, int height) {
     // Create the object
     m_cube = new Object();
     m_floor = new Object();
-    if (!m_cube->Init("../meshes/Torus Knot.obj", "../textures/chrome_mercury.jpg")) {
+    if (!m_cube->Init("../meshes/Torus Knot.obj")) {
         printf("Object failed to init\n");
         return false;
     }
-    if (!m_floor->Init("../meshes/plane.obj", "../textures/stone_floor.jpg")) {
+    if (!m_floor->Init("../meshes/plane.obj")) {
         printf("floor failed to init\n");
         return false;
     }
@@ -123,6 +124,21 @@ bool Graphics::Initialize(int width, int height) {
     m_spotlight.position = glm::vec4(5, 2, 0, 1);
     m_spotlight.diffuse = glm::vec4(1, 1, 1, 0);
     m_spotlight.direction = glm::normalize(m_spotlight.position);
+
+    // load all the textures for the people
+    if (!TextureManager::getInstance()->initHandler(m_shader)) {
+        printf("unable to init texture manager handler\n");
+        return false;
+    }
+    if (!TextureManager::getInstance()->addTexture("bricks", "../textures/stone_floor.jpg")) {
+
+    }
+    if (!TextureManager::getInstance()->addTexture("chrome", "../textures/chrome_mercury.jpg")) {
+
+    }
+
+    m_cube->SetTextureID("chrome");
+    m_floor->SetTextureID("bricks");
 
     //enable depth testing
     glEnable(GL_DEPTH_TEST);

--- a/PA26/src/texture.cpp
+++ b/PA26/src/texture.cpp
@@ -1,0 +1,46 @@
+//
+// Created by Daniel Lopez on 10/30/17.
+//
+
+#include "texture.h"
+
+Texture::Texture() : textureHandler(0) {
+
+}
+
+Texture::~Texture() {
+    if (textureHandler != 0) {
+        glDeleteTextures(1, &textureHandler);
+    }
+}
+
+bool Texture::loadTexture(const std::string &filename) {
+    Magick::Image textureImage;
+    Magick::Blob blob;
+    textureImage.read(filename);
+    size_t width = textureImage.columns();
+    size_t height = textureImage.rows();
+    textureImage.write(&blob, "RGBA");
+
+    if (!textureImage.isValid()) {
+        return false;
+    }
+
+    glGenTextures(1, &textureHandler);
+    glBindTexture(GL_TEXTURE_2D, textureHandler);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR); //or GL_NEAREST
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR); //or GL_NEAREST
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, blob.data());
+
+    return true;
+}
+
+void Texture::enable(GLenum textureUnit) {
+    glActiveTexture(textureUnit);
+    glBindTexture(GL_TEXTURE_2D, textureHandler);
+}
+
+void Texture::disable() {
+    glDisable(GL_TEXTURE_2D);
+}
+

--- a/PA26/src/textureManager.cpp
+++ b/PA26/src/textureManager.cpp
@@ -1,0 +1,52 @@
+//
+// Created by Daniel Lopez on 10/30/17.
+//
+
+#include "textureManager.h"
+
+TextureManager* TextureManager::instance = nullptr;
+
+TextureManager* TextureManager::getInstance() {
+    if (instance == nullptr) {
+        instance = new TextureManager();
+    }
+    return instance;
+}
+
+TextureManager::TextureManager() : samplerHander(0) {
+
+}
+
+bool TextureManager::initHandler(Shader *shaderManager) {
+    samplerHander = shaderManager->GetUniformLocation("gSampler");
+    return samplerHander != INVALID_UNIFORM_LOCATION;
+}
+
+bool TextureManager::addTexture(const string textName, string fileName) {
+    auto* texture = new Texture;
+
+    if (!texture->loadTexture(fileName)){
+        printf("texture manager couldn't add texture with filename %s", fileName.c_str());
+        return false;
+    }
+    textures.insert({textName, texture});
+    return true;
+}
+
+void TextureManager::setTextureUnit(unsigned int samplerIndex) {
+    if (samplerHander != 0) {
+        glUniform1i(samplerHander, samplerIndex);
+    }
+}
+
+void TextureManager::enableTexture(string textName, GLenum textureUnit) {
+    if (textures.find(textName) != textures.end()) {
+        textures[textName]->enable(textureUnit);
+    }
+}
+
+void TextureManager::disableTexture(string textName) {
+    if (textures.find(textName) != textures.end()) {
+        textures[textName]->disable();
+    }
+}


### PR DESCRIPTION
 - Changed Textures to use `TextureManager` instead of having each object carry their own texture (to save buffer space)
 - `Texture manager` uses singleton design pattern
 - It keeps tracks of `Textures`